### PR TITLE
Allow setting the listening port by a command flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/casbin/casbin/v2 v2.0.1
 	github.com/casbin/gorm-adapter/v2 v2.0.0
 	github.com/golang/protobuf v1.3.2
+	github.com/stretchr/testify v1.3.0
 	google.golang.org/grpc v1.23.0
 )

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net"
 
@@ -26,12 +28,16 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-const (
-	port = ":50051"
-)
-
 func main() {
-	lis, err := net.Listen("tcp", port)
+	var port int
+	flag.IntVar(&port, "port", 50051, "listening port")
+	flag.Parse()
+
+	if port < 1 || port > 65535 {
+		panic(fmt.Sprintf("invalid port number: %d", port))
+	}
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
@@ -39,6 +45,7 @@ func main() {
 	pb.RegisterCasbinServer(s, server.NewServer())
 	// Register reflection service on gRPC server.
 	reflection.Register(s)
+	log.Println("Listening on", port)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}


### PR DESCRIPTION
The listening port of the server can now be changed using a command line
flag. By default, it use the old 50051 port. Also display a log
indicating that the server is listening to have some feedback when
starting it.

Change-Id: I4ea3adb2f0b7abeb2b808d70d6d0c0f2fb6f1e5e
Signed-off-by: Loïc Collignon <loic.collignon@iot.bzh>