### PR TITLE
feat: Support environment variables for config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To allow Casbin-Server to be production-ready, the adapter configuration support
   "dbSpecified" : true
 }
 ```
+The connection config file path can also be set using the environment variable `CONNECTION_CONFIG_PATH`. If this variable is not set, connection config is read from the path "config/connection_config.json".
  
 ## Limitation of ABAC
 

--- a/config/connection_config_psql_example.json
+++ b/config/connection_config_psql_example.json
@@ -1,6 +1,6 @@
 {
   "driver": "postgres",
   "connection": "host=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=$DB_NAME password=$DB_PASSWORD",
-  "enforcer": "examples/rbac_policy.csv",
+  "enforcer": "$MODEL_PATH",
   "dbSpecified" : true
 }

--- a/config/connection_config_psql_example.json
+++ b/config/connection_config_psql_example.json
@@ -1,6 +1,6 @@
 {
   "driver": "postgres",
   "connection": "host=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=$DB_NAME password=$DB_PASSWORD",
-  "enforcer": "$MODEL_PATH",
+  "enforcer": "examples/rbac_policy.csv",
   "dbSpecified" : true
 }

--- a/server/adapter.go
+++ b/server/adapter.go
@@ -24,8 +24,8 @@ import (
 
 	pb "github.com/casbin/casbin-server/proto"
 	"github.com/casbin/casbin/v2/persist"
-	"github.com/casbin/casbin/v2/persist/file-adapter"
-	"github.com/casbin/gorm-adapter/v2"
+	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
+	gormadapter "github.com/casbin/gorm-adapter/v2"
 	//_ "github.com/jinzhu/gorm/dialects/mssql"
 	//_ "github.com/jinzhu/gorm/dialects/mysql"
 	//_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -64,13 +64,26 @@ func newAdapter(in *pb.NewAdapterRequest) (persist.Adapter, error) {
 }
 
 func checkLocalConfig(in *pb.NewAdapterRequest) *pb.NewAdapterRequest {
-	cfg := LoadConfiguration("config/connection_config.json")
+	cfg := LoadConfiguration(getLocalConfigPath())
 	if in.ConnectString == "" || in.DriverName == "" {
 		in.DriverName = cfg.Driver
 		in.ConnectString = cfg.Connection
 		in.DbSpecified = cfg.DBSpecified
 	}
 	return in
+}
+
+const (
+	configFileDefaultPath             = "config/connection_config.json"
+	configFilePathEnvironmentVariable = "CASBIN_CONFIG_PATH"
+)
+
+func getLocalConfigPath() string {
+	configFilePath := os.Getenv(configFilePathEnvironmentVariable)
+	if configFilePath == "" {
+		configFilePath = configFileDefaultPath
+	}
+	return configFilePath
 }
 
 func LoadConfiguration(file string) Config {
@@ -88,6 +101,7 @@ func LoadConfiguration(file string) Config {
 	config.Connection = re.ReplaceAllStringFunc(config.Connection, func(s string) string {
 		return os.Getenv(strings.TrimPrefix(s, `$`))
 	})
+	config.Enforcer = re.ReplaceAllString(config.Enforcer, os.Getenv(strings.TrimPrefix(config.Enforcer, `$`)))
 
 	return config
 }

--- a/server/adapter.go
+++ b/server/adapter.go
@@ -101,7 +101,6 @@ func LoadConfiguration(file string) Config {
 	config.Connection = re.ReplaceAllStringFunc(config.Connection, func(s string) string {
 		return os.Getenv(strings.TrimPrefix(s, `$`))
 	})
-	config.Enforcer = re.ReplaceAllString(config.Enforcer, os.Getenv(strings.TrimPrefix(config.Enforcer, `$`)))
 
 	return config
 }

--- a/server/adapter.go
+++ b/server/adapter.go
@@ -75,7 +75,7 @@ func checkLocalConfig(in *pb.NewAdapterRequest) *pb.NewAdapterRequest {
 
 const (
 	configFileDefaultPath             = "config/connection_config.json"
-	configFilePathEnvironmentVariable = "CASBIN_CONFIG_PATH"
+	configFilePathEnvironmentVariable = "CONNECTION_CONFIG_PATH"
 )
 
 func getLocalConfigPath() string {

--- a/server/adapter_test.go
+++ b/server/adapter_test.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLocalConfig(t *testing.T) {
+	assert.Equal(t, configFileDefaultPath, getLocalConfigPath(), "read from default connection config path if environment variable is not set")
+
+	os.Setenv(configFilePathEnvironmentVariable, "dir/custom_path.json")
+	assert.Equal(t, "dir/custom_path.json", getLocalConfigPath())
+}

--- a/server/enforcer.go
+++ b/server/enforcer.go
@@ -82,7 +82,7 @@ func (s *Server) NewEnforcer(ctx context.Context, in *pb.NewEnforcerRequest) (*p
 	}
 
 	if in.ModelText == "" {
-		cfg := LoadConfiguration("config/connection_config.json")
+		cfg := LoadConfiguration(getLocalConfigPath())
 		data, err := ioutil.ReadFile(cfg.Enforcer)
 		if err != nil {
 			return &pb.NewEnforcerReply{Handler: 0}, err


### PR DESCRIPTION
### What this PR does
Addresses https://github.com/casbin/casbin-server/issues/51 to support environment variables for connection config path.

### Summary of changes
- Introduced a new environment variable `CONNECTION_CONFIG_PATH`. Connection config is read from this path if set, or falls back to the default "config/connection_config.json". This avoids a breaking change.
- Added a test to verify this change.

Fix: https://github.com/casbin/casbin-server/issues/51