### PR TITLE
fix: Use adapter from config as default

### DIFF
--- a/server/enforcer.go
+++ b/server/enforcer.go
@@ -96,7 +96,12 @@ func (s *Server) NewEnforcer(ctx context.Context, in *pb.NewEnforcerRequest) (*p
 			return &pb.NewEnforcerReply{Handler: 0}, err
 		}
 
-		e, err = casbin.NewEnforcer(m)
+		a, err = newAdapter(&pb.NewAdapterRequest{})
+		if err != nil {
+			return &pb.NewEnforcerReply{Handler: 0}, err
+		}
+
+		e, err = casbin.NewEnforcer(m, a)
 		if err != nil {
 			return &pb.NewEnforcerReply{Handler: 0}, err
 		}


### PR DESCRIPTION
**Issue**
If client start enforcer with empty config adapter from config is not applied
Client
```go
cxt := context.Background()
c, err := client.NewClient(cxt, "127.0.0.1:50051", grpc.WithInsecure())
if err != nil {
	panic(err)
}
enforcer, err := c.NewEnforcer(cxt, client.Config{})
```

Fix: https://github.com/casbin/casbin-server/issues/59