### PR TITLE
feat: replace ioutils.ReadFile functions by os.ReadFile due to deprecation

### DIFF
--- a/examples/rbac_with_domains_model.conf
+++ b/examples/rbac_with_domains_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act

--- a/examples/rbac_with_domains_policy.csv
+++ b/examples/rbac_with_domains_policy.csv
@@ -1,0 +1,6 @@
+p, admin, domain1, data1, read
+p, admin, domain1, data1, write
+p, admin, domain2, data2, read
+p, admin, domain2, data2, write
+g, alice, admin, domain1
+g, bob, admin, domain2

--- a/server/enforcer.go
+++ b/server/enforcer.go
@@ -17,7 +17,7 @@ package server
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 
@@ -98,7 +98,7 @@ func (s *Server) NewEnforcer(ctx context.Context, in *pb.NewEnforcerRequest) (*p
 
 	if in.ModelText == "" {
 		cfg := LoadConfiguration(getLocalConfigPath())
-		data, err := ioutil.ReadFile(cfg.Enforcer)
+		data, err := os.ReadFile(cfg.Enforcer)
 		if err != nil {
 			return &pb.NewEnforcerReply{Handler: 0}, err
 		}

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -16,7 +16,7 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	pb "github.com/casbin/casbin-server/proto"
@@ -54,7 +54,7 @@ func TestRBACModel(t *testing.T) {
 		t.Error(err)
 	}
 
-	modelText, err := ioutil.ReadFile("../examples/rbac_model.conf")
+	modelText, err := os.ReadFile("../examples/rbac_model.conf")
 	if err != nil {
 		t.Error(err)
 	}
@@ -85,7 +85,7 @@ func TestABACModel(t *testing.T) {
 	s := NewServer()
 	ctx := context.Background()
 
-	modelText, err := ioutil.ReadFile("../examples/abac_model.conf")
+	modelText, err := os.ReadFile("../examples/abac_model.conf")
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -117,7 +117,7 @@ func TestABACModel(t *testing.T) {
 func testModel(t *testing.T, s *Server, enforcerHandler int32, sub string, obj string, act string, res bool) {
 	t.Helper()
 
-	reply, err := s.Enforce(nil, &pb.EnforceRequest{EnforcerHandler: enforcerHandler, Params: []string{sub, obj, act}})
+	reply, err := s.Enforce(context.TODO(), &pb.EnforceRequest{EnforcerHandler: enforcerHandler, Params: []string{sub, obj, act}})
 	assert.NoError(t, err)
 
 	if reply.Res != res {

--- a/server/rbac_api_test.go
+++ b/server/rbac_api_test.go
@@ -239,3 +239,22 @@ func TestPermissionAPI(t *testing.T) {
 	testEnforceWithoutUsers(t, e, "bob", "read", false)
 	testEnforceWithoutUsers(t, e, "bob", "write", false)
 }
+
+func testGetDomains(t *testing.T, e *testEngine, name string, res []string) {
+	t.Helper()
+	reply, err := e.s.GetDomains(e.ctx, &pb.UserRoleRequest{EnforcerHandler: e.h, User: name})
+	assert.NoError(t, err)
+
+	t.Log("Domains for ", name, ": ", reply.Array)
+
+	if !util.SetEquals(res, reply.Array) {
+		t.Error("Domains for ", name, ": ", reply.Array, ", supposed to be ", res)
+	}
+}
+
+func TestRoleDomainAPI(t *testing.T) {
+	e := newTestEngine(t, "file", "../examples/rbac_with_domains_policy.csv", "../examples/rbac_with_domains_model.conf")
+
+	testGetDomains(t, e, "alice", []string{"domain1"})
+	testGetDomains(t, e, "bob", []string{"domain2"})
+}


### PR DESCRIPTION
Update ReadFile function package due to deprecation of ioutils version on Golang 1.16