### PR TITLE
feat: fix the CI dockerhub release error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@ ENV GO111MODULE=on \
     GOOS=linux \
     GOARCH=amd64
 
-# Get grpc
-RUN go get google.golang.org/grpc
+# Download dependencies
+RUN go mod download
 
 # Install protoc-gen-go
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
 # Copy the source and generate the .proto file
 ADD . /go/src/github.com/casbin/casbin-server
@@ -39,9 +39,6 @@ WORKDIR $GOPATH/src/github.com/casbin/casbin-server
 RUN protoc --go_out=. --go_opt=paths=source_relative \
     --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false \
     --go-grpc_opt=paths=source_relative proto/casbin.proto
-
-# Download dependencies
-RUN go mod download
 
 # Install app
 RUN go install .


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-server/issues/117

Because of this project is using golang version 1.19, We should choice a good versions for packages.

Changes:
- Changed version of google.golang.org/protobuf/cmd/protoc-gen-go from @latest to @v1.28.0
- Changed version of google.golang.org/protobuf/cmd/protoc-gen-go from @latest to @v1.2.0
- Download modules with `go mod download` command instead of downloading packages with latest versions like: "RUN go get google.golang.org/grpc"